### PR TITLE
Upload latest version only

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -130,7 +130,7 @@ pipeline {
                             docker tag semantic_web sodaliteh2020/semantic_web:${BRANCH_NAME}
                             docker tag semantic_web sodaliteh2020/semantic_web
                             docker push sodaliteh2020/semantic_web:${BRANCH_NAME}
-                            docker push sodaliteh2020/semantic_web
+                            docker push sodaliteh2020/semantic_web:latest
                         """
                 }
             }
@@ -145,7 +145,7 @@ pipeline {
                             docker tag graph_db sodaliteh2020/graph_db:${BRANCH_NAME}
                             docker tag graph_db sodaliteh2020/graph_db
                             docker push sodaliteh2020/graph_db:${BRANCH_NAME}
-                            docker push sodaliteh2020/graph_db
+                            docker push sodaliteh2020/graph_db:latest
                         """
                 }
             }


### PR DESCRIPTION
CURRENT STATE: command `docker push sodaliteh2020/[component-name]` without tag specified uploads all versions, that are still present on jenkins, to Dockerhub
PROPOSED CHANGE: command `docker push sodaliteh2020/[component-name]:latest`, that will upload only tag `latest`

This fix should remove unnecessary uploading of all version and long push times (sometimes more than an hour)
