### PR TITLE
Adding artifact log rotation

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,8 @@
 pipeline {
-  options { disableConcurrentBuilds() }
+  options { 
+	  disableConcurrentBuilds() 
+	  buildDiscarder logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '30', daysToKeepStr: '', numToKeepStr: '')
+  }
   agent { label 'docker-slave' }
   environment {
        // OPENSTACK SETTINGS


### PR DESCRIPTION
Artifact log rotation is needed to prevent Jenkins VM space from getting filled up.