### PR TITLE
Bump iac-modules

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -180,7 +180,7 @@ pipeline {
                     python3 -m pip install opera[openstack]==0.6.4 docker
                     ansible-galaxy install -r openstack-blueprint/requirements.yml --force
                     rm -r -f openstack-blueprint/modules/
-                    git clone -b 3.2.1 https://github.com/SODALITE-EU/iac-modules.git openstack-blueprint/modules/
+                    git clone -b 3.4.1 https://github.com/SODALITE-EU/iac-modules.git openstack-blueprint/modules/
                     cp ${ca_crt_file} openstack-blueprint/modules/docker/artifacts/ca.crt
                     cp ${ca_crt_file} openstack-blueprint/modules/misc/tls/artifacts/ca.crt
                     cp ${ca_key_file} openstack-blueprint/modules/docker/artifacts/ca.key

--- a/openstack-blueprint/README.md
+++ b/openstack-blueprint/README.md
@@ -11,7 +11,7 @@ python3 -m venv venv
 python3 -m pip install --upgrade pip
 python3 -m pip install opera[openstack]==0.6.4 docker
 ansible-galaxy install -r openstack-blueprint/requirements.yml --force
-git clone -b 3.2.1 https://github.com/SODALITE-EU/iac-modules.git openstack-blueprint/modules/
+git clone -b 3.4.1 https://github.com/SODALITE-EU/iac-modules.git openstack-blueprint/modules/
 envsubst < openstack-blueprint/input.yaml.tmpl > openstack-blueprint/input.yaml
 cd openstack-blueprint
 opera deploy service.yaml -i input.yaml               


### PR DESCRIPTION
This contribution bumps SODALITE iac-modules, used in CI/CD pipeline and with openstack-blueprint. New modules' version provides pip docker bugfix for deployment to centos7 distribution